### PR TITLE
Move inline styles to CSS

### DIFF
--- a/HOURS.html
+++ b/HOURS.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Job Hours Tracker</title>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;600&amp;display=swap" rel="stylesheet">
     <style>
         body {
             font-family: 'Roboto', sans-serif;
@@ -55,12 +55,7 @@
             text-align: center;
         }
 
-        .day-total {
-            background: #455a64;
-            color: #fff;
-            /* font-weight: bold; */
-            text-align: center;
-        }
+
 
         .day-table th,
         .day-table td {
@@ -186,6 +181,77 @@
         .logo-container img {
             height: 3vw;
         }
+
+        .header-left {
+            display: flex;
+            align-items: left;
+            gap: 10px;
+        }
+
+        .days-manager-dropdown {
+            align-items: left;
+            display: none;
+            position: relative;
+            left: 0;
+            top: 0;
+            background: #fff;
+            border: 1px solid #ccc;
+            z-index: 1000;
+            padding: 0;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            min-width: 220px;
+        }
+
+        .day-header-wrapper {
+            padding: 0;
+            background: transparent;
+            border-bottom: none;
+        }
+
+        .day-header-inner {
+            display: flex;
+            width: 100%;
+        }
+
+        .day-header-left {
+            flex: 1;
+            background: #2a3f54;
+            color: #fff;
+            font-weight: bold;
+            text-align: center;
+            padding: 12px 0;
+            border-right: 1px solid #fff;
+        }
+
+        .day-header-right {
+            flex: 1;
+            background: #2a3f54;
+            color: #fff;
+            font-weight: bold;
+            text-align: center;
+            padding: 12px 0;
+        }
+
+        .job-col-width { width: 15%; }
+        .hours-col-width { width: 10%; text-align: center; }
+        .address-col-width { width: 35%; text-align: center; }
+        .desc-col-width { width: 30%; text-align: center; }
+        .actions-col-width { width: 10%; white-space: nowrap; text-align: center; }
+
+        .inline-flex-gap { display: inline-flex; gap: 4px; }
+        .no-margin { margin: 0; }
+
+        .table-addrow { text-align: center; }
+
+        .day-total {
+            background: #607d8b;
+            color: #fff;
+            font-weight: bold;
+        }
+
+        .text-left { text-align: left; }
+        .text-center { text-align: center; }
+        .days-manager-label { display: flex; align-items: center; margin-bottom: 4px; }
     </style>
 </head>
 
@@ -196,10 +262,10 @@
                 alt="white-orange-wordstrans3" border="0"></a>
     </div>
     <div class="header">
-        <div style="align-items:left; gap:10px;">
+        <div class="header-left">
             <button class="btn btn-edit" id="daysManagerBtn" type="button">Days Worked Manager</button>
             <div id="daysManagerDropdown"
-                style="align-items:left; display:none; position:relative; left:0; top:0px; background:#fff; border:1px solid #ccc; z-index:1000; padding:0px; box-shadow:0 2px 8px rgba(0,0,0,0.15); min-width:220px;">
+                class="days-manager-dropdown">
             </div>
         </div>
         <select id="payPeriodSelect" class="pay-period-select"></select>
@@ -347,9 +413,7 @@
                 const hasData = jobs[date] && jobs[date].length > 0;
                 // Always show in manager, but only allow unchecking weekdays, weekends only if checked or has data
                 const label = document.createElement("label");
-                label.style.display = "flex";
-                label.style.alignItems = "center";
-                label.style.marginBottom = "4px";
+                label.className = "days-manager-label";
                 const cb = document.createElement("input");
                 cb.type = "checkbox";
                 cb.checked = !!window.daysManagerVisibility[date];
@@ -375,15 +439,19 @@
                 const dateStr = dayObj.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: '2-digit' });
                 header.innerHTML = `
       <tr>
-        <th class="day-header" colspan="5" style="padding:0; background:transparent; border-bottom:none;">
-          <div style="display:flex; width:100%;">
-            <div style="flex:1; background:#2a3f54; color:#fff; font-weight:bold; text-align:center; padding:12px 0; border-right:1px solid #fff;">${dayName}</div>
-            <div style="flex:1; background:#2a3f54; color:#fff; font-weight:bold; text-align:center; padding:12px 0;">${dateStr}</div>
+        <th class="day-header day-header-wrapper" colspan="5">
+          <div class="day-header-inner">
+            <div class="day-header-left">${dayName}</div>
+            <div class="day-header-right">${dateStr}</div>
           </div>
         </th>
       </tr>
       <tr>
-        <th class="job-col">Job</th><th>Hours</th><th>Address</th><th>Description</th><th>Actions</th>
+        <th class="job-col job-col-width">Job</th>
+        <th class="hours-col-width">Hours</th>
+        <th class="address-col-width">Address</th>
+        <th class="desc-col-width">Description</th>
+        <th class="actions-col-width">Actions</th>
       </tr>`;
                 dayTable.appendChild(header);
                 const tbody = document.createElement("tbody");
@@ -391,29 +459,29 @@
                     const row = document.createElement("tr");
                     if (job.locked) {
                         row.innerHTML = `
-          <td class="job-col" style="width:15%;">${job.job}</td>
-          <td style="width:10%; text-align:center;">${Number(job.hours).toFixed(1)}</td>
-          <td style="width:35%; text-align:center;">${job.address || ""}</td>
-          <td style="width:30%; text-align:center;">${job.desc}</td>
-          <td style="width:10%; white-space:nowrap; text-align:center;">
-            <span style="display:inline-flex; gap:4px;">
-              <button class="btn btn-edit" style="margin:0;" onclick="toggleEdit('${date}', ${idx}, false)">Edit</button>
-              <button class="btn btn-delete" style="margin:0;" onclick="deleteJob('${date}', ${idx})">X</button>
+          <td class="job-col job-col-width">${job.job}</td>
+          <td class="hours-col-width">${Number(job.hours).toFixed(1)}</td>
+          <td class="address-col-width">${job.address || ""}</td>
+          <td class="desc-col-width">${job.desc}</td>
+          <td class="actions-col-width">
+            <span class="inline-flex-gap">
+              <button class="btn btn-edit no-margin" onclick="toggleEdit('${date}', ${idx}, false)">Edit</button>
+              <button class="btn btn-delete no-margin" onclick="deleteJob('${date}', ${idx})">X</button>
             </span>
           </td>`;
                     } else {
                         row.innerHTML = `
-          <td class="job-col" style="width:15%;"><input type="text" class="job-input" id="job_${date}_${idx}" value="${job.job}" oninput="jobInputChange('${date}', ${idx})"></td>
-          <td style="width:10%; text-align:center;">${generateHoursDropdown(`hours_${date}_${idx}`, job.hours)}</td>
-          <td class="address-cell" style="width:35%;">
+          <td class="job-col job-col-width"><input type="text" class="job-input" id="job_${date}_${idx}" value="${job.job}" oninput="jobInputChange('${date}', ${idx})"></td>
+          <td class="hours-col-width">${generateHoursDropdown(`hours_${date}_${idx}`, job.hours)}</td>
+          <td class="address-cell address-col-width">
             <input type="text" id="addr_${date}_${idx}" value="${job.address || ""}">
             <button class="btn btn-locate" onclick="getCurrentAddress('${date}', ${idx})">📍</button>
           </td>
-          <td style="width:30%; text-align:center;"><input type="text" id="desc_${date}_${idx}" value="${job.desc}"></td>
-          <td style="width:10%; white-space:nowrap; text-align:center;">
-            <span style="display:inline-flex; gap:4px;">
-              <button class="btn btn-check" style="margin:0;" onclick="toggleEdit('${date}', ${idx}, true)">✔</button>
-              <button class="btn btn-delete" style="margin:0;" onclick="deleteJob('${date}', ${idx})">X</button>
+          <td class="desc-col-width"><input type="text" id="desc_${date}_${idx}" value="${job.desc}"></td>
+          <td class="actions-col-width">
+            <span class="inline-flex-gap">
+              <button class="btn btn-check no-margin" onclick="toggleEdit('${date}', ${idx}, true)">✔</button>
+              <button class="btn btn-delete no-margin" onclick="deleteJob('${date}', ${idx})">X</button>
             </span>
           </td>`;
                     }
@@ -422,16 +490,16 @@
                 // Total row at the bottom
                 const totalRow = document.createElement("tr");
                 totalRow.innerHTML = `
-      <td class="day-total" style="background: #607d8b; color: #fff; font-weight: bold; text-align: left;">Total</td>
-      <td class="day-total" style="background: #607d8b; color: #fff; font-weight: bold; text-align: center;">${dailyTotal.toFixed(1)}</td>
-      <td class="day-total" style="background: #607d8b; text-align: center;"></td>
-      <td class="day-total" style="background: #607d8b; text-align: center;"></td>
-      <td class="day-total" style="background: #607d8b; text-align: center;"></td>
+      <td class="day-total text-left">Total</td>
+      <td class="day-total text-center">${dailyTotal.toFixed(1)}</td>
+      <td class="day-total text-center"></td>
+      <td class="day-total text-center"></td>
+      <td class="day-total text-center"></td>
     `;
                 tbody.appendChild(totalRow);
                 // Add Job button row (centered, unaffected)
                 const addRow = document.createElement("tr");
-                addRow.innerHTML = `<td colspan="5" style="text-align: center;"><button class="btn btn-add" onclick="addJob('${date}')">+ Add Job</button></td>`;
+                addRow.innerHTML = `<td colspan="5" class="table-addrow"><button class="btn btn-add" onclick="addJob('${date}')">+ Add Job</button></td>`;
                 tbody.appendChild(addRow);
                 dayTable.appendChild(tbody);
                 container.appendChild(dayTable);


### PR DESCRIPTION
## Summary
- clean up inline styles by replacing them with CSS classes
- update HTML to use new classes
- update JavaScript string templates to use class-based styling

## Testing
- `tidy -q -e HOURS.html`

------
https://chatgpt.com/codex/tasks/task_e_688ae767b2c0833098902681911f6da2