### PR TITLE
fix jsonbin helper

### DIFF
--- a/HOURS.html
+++ b/HOURS.html
@@ -456,7 +456,7 @@
       }
 
       function getJSONBIN_URL(id) {
-        const urlString = "https://api.jsonbin.io/v3/b/" + id;
+        return `https://api.jsonbin.io/v3/b/${id}`;
       }
     
       


### PR DESCRIPTION
## Summary
- ensure JSONBin URL helper returns the constructed URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68903bf871b88330900a8eab04159c7c