### PR TITLE
Implement login and account creation sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1445,8 +1445,12 @@
           headers: { "X-Master-Key": JSONBIN_KEY }
         });
         const data = await res.json();
-        mappings = data.record || {};
-      } catch (e) {
+        if (!data.record) {
+          console.warn("API response missing 'record' property or it is falsy. Falling back to empty object.", data);
+          mappings = {};
+        } else {
+          mappings = data.record;
+        }
         mappings = {};
       }
       setupLoginEvents();

--- a/index.html
+++ b/index.html
@@ -472,7 +472,15 @@
         },
         body: JSON.stringify({ payPeriods: {}, jobMeta: {}, user: currentUser }),
       });
-      if (!res.ok) throw new Error("Failed to create bin");
+      if (!res.ok) {
+        let errorDetails;
+        try {
+          errorDetails = await res.text();
+        } catch (e) {
+          errorDetails = "(failed to read response body)";
+        }
+        throw new Error(`Failed to create bin (status: ${res.status} ${res.statusText}): ${errorDetails}`);
+      }
       const data = await res.json();
       return data.metadata.id;
     }

--- a/index.html
+++ b/index.html
@@ -356,10 +356,34 @@
 </head>
 
 <body>
-  <div class="logo-container">
-    <a href="https://ibb.co/NgFdFnhr"><img src="https://i.ibb.co/HLKfKpvC/DDFGTDGDsdfsdf-G.png"
-        alt="Easton Construction Logo" border="0" /></a>
+  <div id="loginSection" style="display: none; flex-direction: column; align-items: center; justify-content: center;">
+    <h1>Login</h1>
+    <div style="display: flex; flex-direction: row; gap: 10px;">
+      <input type="text" id="firstName" placeholder="First Name" style="margin-bottom: 10px; width: 140px; font-size: 26px;">
+      <input type="text" id="lastName" placeholder="Last Name" style="margin-bottom: 10px; width: 140px; font-size: 26px;">
+    </div>
+    <input type="password" id="pin" placeholder="Enter Pin #" style="margin-bottom: 10px; width: 310px; font-size: 26px">
+    <button id="loginButton" style="margin-bottom: 10px; width: 330px; font-size: 26px">Login</button>
+    <button id="createAccountButton" style="margin-bottom: 10px; width: 330px; font-size: 26px">Create Account</button>
   </div>
+
+  <div id="createAccountSection" style="display: none; flex-direction: column; align-items: center; justify-content: center;">
+    <h1>Create Account</h1>
+    <div style="display: flex; flex-direction: row; gap: 10px;">
+      <input type="text" id="createAccountFirstName" placeholder="First Name" style="margin-bottom: 10px; width: 140px; font-size: 26px">
+      <input type="text" id="createAccountLastName" placeholder="Last Name" style="margin-bottom: 10px; width: 140px; font-size: 26px">
+    </div>
+    <input type="password" id="createAccountPin" placeholder="Enter Pin # (4 or more)" style="margin-bottom: 10px; width: 310px; font-size: 26px">
+    <input type="password" id="createAccountRePin" placeholder="Re-Enter Pin #" style="margin-bottom: 10px; width: 310px; font-size: 26px">
+    <button id="submitButton" style="margin-bottom: 10px; width: 330px; font-size: 26px">Submit</button>
+    <button id="backButton" style="margin-bottom: 10px; width: 330px; font-size: 26px">Back</button>
+  </div>
+
+  <div id="mainContent" style="display: none;">
+    <div class="logo-container">
+      <a href="https://ibb.co/NgFdFnhr"><img src="https://i.ibb.co/HLKfKpvC/DDFGTDGDsdfsdf-G.png"
+          alt="Easton Construction Logo" border="0" /></a>
+    </div>
   <div class="header">
     <div class="header-left">
       <button class="btn btn-edit" id="daysManagerBtn" type="button">
@@ -420,6 +444,8 @@
   <div id="logPanel"></div>
   <div id="metaPanel"></div>
 
+  </div>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script>
 
@@ -434,68 +460,21 @@
 
 
     async function generateBinId(firstName, lastName, pin) {
-      currentUser = `${firstName} ${lastName}`;
       const binName = `${firstName}_${lastName}`;
-      try {
-        console.log("Starting bin creation process...");
-        console.log("Request details:", {
-          url: "https://api.jsonbin.io/v3/b",
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Master-Key": JSONBIN_KEY,
-            "X-Bin-Name": binName,
-            "X-Bin-Private": "true",
-          },
-          body: JSON.stringify({ payPeriods: {}, jobMeta: {}, user: currentUser }),
-        });
-
-        // Step 1: Create a new bin
-        const response = await fetch("https://api.jsonbin.io/v3/b", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Master-Key": JSONBIN_KEY,
-            "X-Bin-Name": binName,
-            "X-Bin-Private": "false",
-          },
-          body: JSON.stringify({ payPeriods: {}, jobMeta: {}, user: currentUser }),
-        });
-
-        console.log("Response status:", response.status);
-        console.log("Response headers:", response.headers);
-
-        if (!response.ok) {
-          const errorDetails = await response.json();
-          console.error("Error response from API:", errorDetails);
-          throw new Error(`Failed to create bin: ${response.statusText}`);
-        }
-
-        const data = await response.json();
-        console.log("Bin creation successful. Response data:", data);
-
-        const binId = data.metadata.id;
-
-        // Step 2: Update mappings with the new bin_id
-        const fullName = currentUser;
-        if (!state[fullName]) state[fullName] = {};
-        state[fullName] = { pin: pin, bin_id: binId };
-
-        // Step 3: Save updated mappings to JSONBin
-        console.log("Saving updated mappings to JSONBin...");
-        const previousBinId = bin_id; // Temporarily store the current bin_id
-        bin_id = mapping_bin_id; // Use mapping_bin_id for saving mappings
-        await saveData();
-        bin_id = previousBinId; // Restore the original bin_id
-
-        bin_id = binId; // Store the bin_id for later use
-
-        return binId;
-      } catch (error) {
-        console.error("Error generating bin ID:", error);
-        alert("Failed to create a new bin. Please try again.");
-        throw error;
-      }
+      currentUser = `${firstName} ${lastName}`;
+      const res = await fetch("https://api.jsonbin.io/v3/b", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Master-Key": JSONBIN_KEY,
+          "X-Bin-Name": binName,
+          "X-Bin-Private": "false",
+        },
+        body: JSON.stringify({ payPeriods: {}, jobMeta: {}, user: currentUser }),
+      });
+      if (!res.ok) throw new Error("Failed to create bin");
+      const data = await res.json();
+      return data.metadata.id;
     }
 
 
@@ -1412,29 +1391,7 @@
         btn.textContent = "Show Meta Data";
       }
     });
-
-
-    // Fetch mappings bin and show login/create UI
-    async function init_login() {
-      // Fetch the mappings bin from JSONBin
-      try {
-        const res = await fetch(`https://api.jsonbin.io/v3/b/${mapping_bin_id}`, {
-          headers: { "X-Master-Key": JSONBIN_KEY }
-        });
-        const data = await res.json();
-        mappings = data.record;
-      } catch (e) {
-        mappings = {};
-      }
-      // Show login or create account UI
-      if (!mappings || Object.keys(mappings).length === 0) {
-        showCreateAccountForm();
-      } else {
-        document.getElementById("loginSection").style.display = "flex";
-        document.getElementById("mainContent").style.display = "none";
-      }
-    }
-
+    
     // Only call this after successful login, with bin_id
     async function init() {
       await fetchData(bin_id);
@@ -1454,130 +1411,113 @@
       render();
     }
 
-    // Run init_login on DOMContentLoaded
+    // ====== Startup: Always DOMContentLoaded ======
+    window.addEventListener("DOMContentLoaded", function() {
+      const test = false; // Set to true for dev, false for real use
 
-    const test = false
-
-    if (test) {
-      bin_id = '68904e93ae596e708fc115c7'
-      currentUser = 'test test'
-      window.addEventListener("DOMContentLoaded", init);
-    } else {
-
-      // Added login and account creation functionality
-      // Hide all content initially and show login section
-      window.addEventListener("DOMContentLoaded", () => {
-        document.body.innerHTML = `
-        <div id="loginSection" style="display: flex; flex-direction: column; align-items: center; justify-content: center;">
-            <h1>Login</h1>
-            <div style="display: flex; flex-direction: row; gap: 10px;">
-                <input type="text" id="firstName" placeholder="First Name" style="margin-bottom: 10px; width: 140px; font-size: 26px;">
-                <input type="text" id="lastName" placeholder="Last Name" style="margin-bottom: 10px; width: 140px; font-size: 26px;">
-            </div>
-            <input type="password" id="pin" placeholder="Enter Pin #" style="margin-bottom: 10px; width: 310px; font-size: 26px">
-            <button id="loginButton" style="margin-bottom: 10px; width: 330px; font-size: 26px">Login</button>
-            <button id="createAccountButton" style="margin-bottom: 10px; width: 330px; font-size: 26px">Create Account</button>
-        </div>
-        <div id="mainContent" style="display: none;">
-            ${document.body.innerHTML}
-        </div>
-    `;
-
-        document.getElementById("loginButton").addEventListener("click", handleLogin);
-        document.getElementById("createAccountButton").addEventListener("click", showCreateAccountForm);
-      });
-
-      function showCreateAccountForm() {
-        const loginSection = document.getElementById("loginSection");
-        loginSection.innerHTML = `
-            <h1>Create Account</h1>
-            <div style="display: flex; flex-direction: row; gap: 10px;">
-                <input type="text" id="createAccountFirstName" placeholder="First Name" style="margin-bottom: 10px; width: 140px; font-size: 26px">
-                <input type="text" id="createAccountLastName" placeholder="Last Name" style="margin-bottom: 10px; width: 140px; font-size: 26px">
-            </div>
-            <input type="password" id="createAccountPin" placeholder="Enter Pin # (4 or more)" style="margin-bottom: 10px; width: 310px; font-size: 26px">
-            <input type="password" id="createAccountRePin" placeholder="Re-Enter Pin #" style="margin-bottom: 10px; width: 310px; font-size: 26px">
-        <button id="submitButton" style="margin-bottom: 10px; width: 330px; font-size: 26px">Submit</button>
-        <button id="backButton" style="margin-bottom: 10px; width: 330px; font-size: 26px">Back</button>
-    `;
-
-        document.getElementById("submitButton").addEventListener("click", handleCreateAccount);
-        document.getElementById("backButton").addEventListener("click", () => location.reload());
-      }
-
-      async function handleCreateAccount() {
-        const firstName = document.getElementById("createAccountFirstName").value.trim();
-        const lastName = document.getElementById("createAccountLastName").value.trim();
-        const fullName = `${firstName} ${lastName}`;
-        const pin = document.getElementById("createAccountPin").value;
-        const rePin = document.getElementById("createAccountRePin").value;
-
-        if (!firstName || !lastName || !pin || !rePin) {
-          alert("All fields are required.");
-          return;
-        }
-
-        if (pin !== rePin) {
-          alert("Pins do not match.");
-          return;
-        }
-
-        if (pin.length < 4) {
-          alert("Pin must be at least 4 characters long.");
-          return;
-        }
-
-        if (!/^\d+$/.test(pin)) {
-          alert("Pin must be numeric.");
-          return;
-        }
-
-        if (mappings[fullName]) {
-          alert("Account already exists.");
-          return;
-        }
-
-        try {
-          bin_id = await generateBinId(firstName, lastName, pin);
-          mappings[fullName] = { pin: pin, bin_id: bin_id };
-          await saveData(mappings, mapping_bin_id);
-          location.reload();
-        } catch (error) {
-          console.error("Error creating account:", error);
-          alert("Failed to create account. Please try again.");
-        }
-      }
-
-      function handleLogin() {
-        const firstName = document.getElementById("firstName").value.trim();
-        const lastName = document.getElementById("lastName").value.trim();
-        const pin = document.getElementById("pin").value;
-
-        const fullName = `${firstName} ${lastName}`;
-
-        if (!mappings || !mappings[fullName] || mappings[fullName].pin !== pin) {
-          alert("Invalid credentials.");
-          return;
-        }
-
-        bin_id = mappings[fullName].bin_id;
-
-        if (bin_id === "root") {
-          alert("Comming Soon!")
-          return;
-        }
-
-        alert(`Welcome, ${fullName}!`);
-        currentUser = fullName;
-
-        document.getElementById("loginSection").style.display = "none";
+      if (test) {
+        bin_id = '68904e93ae596e708fc115c7'
+        currentUser = 'test test'
         document.getElementById("mainContent").style.display = "block";
-        init(bin_id);
+        document.getElementById("loginSection").style.display = "none";
+        document.getElementById("createAccountSection").style.display = "none";
+        init();
+      } else {
+        document.getElementById("loginSection").style.display = "flex";
+        document.getElementById("mainContent").style.display = "none";
+        document.getElementById("createAccountSection").style.display = "none";
+        fetchMappings();
+      }
+    });
+
+    // ====== Mappings Bin Logic ======
+    async function fetchMappings() {
+      try {
+        const res = await fetch(`https://api.jsonbin.io/v3/b/${mapping_bin_id}`, {
+          headers: { "X-Master-Key": JSONBIN_KEY }
+        });
+        const data = await res.json();
+        mappings = data.record || {};
+      } catch (e) {
+        mappings = {};
+      }
+      setupLoginEvents();
+    }
+
+    function setupLoginEvents() {
+      document.getElementById("loginButton").onclick = handleLogin;
+      document.getElementById("createAccountButton").onclick = function() {
+        document.getElementById("loginSection").style.display = "none";
+        document.getElementById("createAccountSection").style.display = "flex";
+      };
+      document.getElementById("submitButton").onclick = handleCreateAccount;
+      document.getElementById("backButton").onclick = function() {
+        document.getElementById("createAccountSection").style.display = "none";
+        document.getElementById("loginSection").style.display = "flex";
+      };
+    }
+
+    async function handleCreateAccount() {
+      const firstName = document.getElementById("createAccountFirstName").value.trim();
+      const lastName = document.getElementById("createAccountLastName").value.trim();
+      const fullName = `${firstName} ${lastName}`;
+      const pin = document.getElementById("createAccountPin").value;
+      const rePin = document.getElementById("createAccountRePin").value;
+
+      if (!firstName || !lastName || !pin || !rePin) {
+        alert("All fields are required.");
+        return;
+      }
+      if (pin !== rePin) {
+        alert("Pins do not match.");
+        return;
+      }
+      if (pin.length < 4) {
+        alert("Pin must be at least 4 characters long.");
+        return;
+      }
+      if (!/^\d+$/.test(pin)) {
+        alert("Pin must be numeric.");
+        return;
+      }
+      if (mappings[fullName]) {
+        alert("Account already exists.");
+        return;
       }
 
+      try {
+        bin_id = await generateBinId(firstName, lastName, pin);
+        mappings[fullName] = { pin: pin, bin_id: bin_id };
+        await saveData(mappings, mapping_bin_id);
+        alert("Account created! Please login.");
+        document.getElementById("createAccountSection").style.display = "none";
+        document.getElementById("loginSection").style.display = "flex";
+      } catch (error) {
+        alert("Failed to create account. Please try again.");
+      }
+    }
 
+    function handleLogin() {
+      const firstName = document.getElementById("firstName").value.trim();
+      const lastName = document.getElementById("lastName").value.trim();
+      const pin = document.getElementById("pin").value;
+      const fullName = `${firstName} ${lastName}`;
 
-      window.addEventListener("DOMContentLoaded", init_login);
+      if (!mappings || !mappings[fullName] || mappings[fullName].pin !== pin) {
+        alert("Invalid credentials.");
+        return;
+      }
+      bin_id = mappings[fullName].bin_id;
+      if (bin_id === "root") {
+        alert("Coming Soon!");
+        return;
+      }
+      alert(`Welcome, ${fullName}!`);
+      currentUser = fullName;
+      document.getElementById("loginSection").style.display = "none";
+      document.getElementById("mainContent").style.display = "block";
+      document.getElementById("createAccountSection").style.display = "none";
+      init();
     }
 
   </script>


### PR DESCRIPTION
## Summary
- add dedicated login and account creation sections with hidden main content
- refactor startup flow to load mappings and show correct section
- create bins publicly and ensure test mode is disabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890786280788330b94985aa5c622aef